### PR TITLE
Added conditional INT typecasting for correct login

### DIFF
--- a/config/middleware.js
+++ b/config/middleware.js
@@ -6,7 +6,14 @@ var passport = require('passport')
 var verifyHandler = function (token, tokenSecret, profile, done) {
     process.nextTick(function () {
 
-        User.findOne({uid: profile.id}).done(function (err, user) {
+        User.findOne(
+                {
+                    or : [
+                            {uid: parseInt(profile.id)}, 
+                            {uid: profile.id}
+                        ]
+                }
+            ).done(function (err, user) {
             if (user) {
                 return done(null, user);
             } else {


### PR DESCRIPTION
The User model saves the 'uid' as an integer, services often send the profile id as string. ParseInt should work on its own, but for best compatibility and to account for possible changes to the User model this should be the best way to find if the user exists already in the model.
